### PR TITLE
fix signwriting behavior in RTL applications

### DIFF
--- a/src/components/sgnw-sign/sgnw-sign.css
+++ b/src/components/sgnw-sign/sgnw-sign.css
@@ -1,2 +1,3 @@
 :host {
+  direction: ltr;
 }


### PR DESCRIPTION
In an LTR app, like English for example, the component shows:
![image](https://user-images.githubusercontent.com/5757359/126859760-10143e82-5865-45a2-9443-cb6f993811fa.png)

However, in RTL, like Hebrew, the component shows:
![image](https://user-images.githubusercontent.com/5757359/126859776-3656c4d1-bc4f-4a53-9c77-4d8797f5c19d.png)

This fix makes it so even if the app is RTL, the `sgnw-component` always shows LTR.